### PR TITLE
Stored Cross Site Scripting (XSS) fix

### DIFF
--- a/vulnerabilities/stored_xss/home.php
+++ b/vulnerabilities/stored_xss/home.php
@@ -62,9 +62,9 @@ Stored Cross Site Scripting attacks happen when the application doesn’t valida
                 echo "<div class=\"row\">";
                 echo "<div class=\"col-md-12\">";
                 echo "<span class=\"glyphicon glyphicon-star\"></span> &nbsp;";
-                    echo ucfirst($usr);
-                echo "<span class=\"pull-right\">",$dt."</span>";
-                echo "<p>".$cmnt."</p>";
+                    echo ucfirst(htmlentities($usr));
+                echo "<span class=\"pull-right\">".$dt."</span>";
+                echo "<p>".htmlentities($cmnt)."</p>";
                 echo "</div>";
                 echo "</div><hr>";
 


### PR DESCRIPTION
Hello,

I am would like recommend to fix Stored Cross Site Scripting flaw.

Stored Cross Site Scripting attacks happen when the application doesn’t validate user inputs against malicious scripts, and it occurs when these scripts get stored on the database. Victim gets infected when they visit web page that loads these malicious scripts from database. For instances, message forum, comments page, visitor logs, profile page, etc.

Read more about Stored XSS: https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)#Stored_XSS_Attacks

I am glad that I helped to make web more secure. Merge please.

Greetings,
