### PR TITLE
Fix unintended XSS in SSRF example. Change link title for SSRF bible.

### DIFF
--- a/vulnerabilities/ssrf_xspa/home.php
+++ b/vulnerabilities/ssrf_xspa/home.php
@@ -11,7 +11,7 @@
         This vulnerability also known as Cross Site Port Attack, happens when an attacker has the ability to initiate requests from the affected server. An attacker can trick the web server that could probability running behind a firewall to send requests to itself to identify services running on it, or can even send out-bond traffic to other servers.
         </p>
         <p>Read more about SSRF <br>
-        <strong><a target="_blank" href="https://docs.google.com/document/d/1v1TkWZtrhzRLy0bYXBcdLUedXGb9njTNIJXa3u9akHM/edit">https://docs.google.com/document/d/1v1TkWZtrhzRLy0bYXBcdLUedXGb9njTNIJXa3u9akHM/edit</a></p></strong>
+        <strong><a target="_blank" href="https://docs.google.com/document/d/1v1TkWZtrhzRLy0bYXBcdLUedXGb9njTNIJXa3u9akHM/edit">SSRF bible. Cheatsheet</a></p></strong>
 
     </div>
 
@@ -33,7 +33,7 @@
                     $remote_content = file_get_contents($_POST['img_url']);
                     $filename = "./images/".rand()."img1.jpg";
                     file_put_contents($filename, $remote_content);
-                    echo $_POST['img_url']."<br>";
+                    echo htmlspecialchars($_POST['img_url'])."<br>";
                     $image = "<img src=\"".$filename."\" width=\"100\" height=\"100\" />";
                 }
                 echo $image;


### PR DESCRIPTION
Also we can use file_get_contents() to read local files. May be we should add some additional checks for http:// in URL for example.
