### PR TITLE
suppress error

### DIFF
--- a/config.php
+++ b/config.php
@@ -4,7 +4,7 @@ $host = "localhost";
 $dbname = 'xvwa';
 $user = 'root';
 $pass = '';
-$conn = mysql_connect($host,$user,$pass);
+$conn = @mysql_connect($host,$user,$pass);
 $conn = mysql_select_db($dbname);
 $conn1 = new PDO("mysql:host=$host;dbname=$dbname", $user, $pass);
 $conn1->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);


### PR DESCRIPTION
This will suppress error which is seen when xvwa is setup on windows. 

Error is "Deprecated: mysql_connect(): The mysql extension is deprecated and will be removed in the future: use mysqli or PDO instead in C:\xampp\htdocs\xvwa\config.php on line 7"
