### PR TITLE
Resolved include() failed to open config.php

### DIFF
--- a/header.php
+++ b/header.php
@@ -15,7 +15,7 @@
         <ul class="nav pull-right navbar-nav">
             <li class="dropdown" id="menuLogin">
                 <?php
-                    include(__DIR__.'/xvwa/config.php');
+                    include(__DIR__.'/config.php');
                     if(isset($_SESSION['user'])){
                         echo "<a href='#' class='dropdown-toggle' data-toggle='dropdown'> " . ucfirst(($_SESSION['user'])) . " <b class='caret'></b></a>";
                         echo "<ul class='dropdown-menu'>";


### PR DESCRIPTION
Resolved Issue 31 (https://github.com/s4n7h0/xvwa/issues/31) where the wrong path of `config.php` in `include()` led to an error.